### PR TITLE
[feat] News 북마크 추가 관련

### DIFF
--- a/Backend/src/main/java/com/fourstit/pocari/controller/MainController.java
+++ b/Backend/src/main/java/com/fourstit/pocari/controller/MainController.java
@@ -1,15 +1,19 @@
 package com.fourstit.pocari.controller;
 
 import com.fourstit.pocari.dto.BookmarkDto;
+import com.fourstit.pocari.dto.BookmarkRequestDto;
 import com.fourstit.pocari.dto.NewsDto;
+import com.fourstit.pocari.entity.Bookmark;
 import com.fourstit.pocari.entity.News;
+import com.fourstit.pocari.entity.User;
 import com.fourstit.pocari.repository.BookmarkRepository;
 import com.fourstit.pocari.repository.NewsRepository;
 import com.fourstit.pocari.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
@@ -32,6 +36,22 @@ public class MainController {
     public List<BookmarkDto> bookmarkList(@PathVariable("userNo") Long userId) {
 
         return  bookmarkRepository.findAllByUserId(userId);
+    }
+
+    @PostMapping("/createbookmark")
+    public ResponseEntity<String> createBookmark(@RequestBody BookmarkRequestDto requestDto) {
+        User user = userRepository.findById(requestDto.getUserId())
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 사용자: " + requestDto.getUserId()));
+        News news = newsRepository.findById(requestDto.getNewsId())
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 뉴스: " + requestDto.getNewsId()));
+
+        Bookmark bookmark = new Bookmark();
+        bookmark.setUserId(user.getUserNo());
+        bookmark.setNewsId(news.getNewsId());
+        bookmark.setCreatedDate(LocalDateTime.now());
+        bookmarkRepository.save(bookmark);
+
+        return ResponseEntity.ok("");
     }
 
     @GetMapping("/detail/{newsNo}")

--- a/Backend/src/main/java/com/fourstit/pocari/dto/BookmarkRequestDto.java
+++ b/Backend/src/main/java/com/fourstit/pocari/dto/BookmarkRequestDto.java
@@ -1,0 +1,13 @@
+package com.fourstit.pocari.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class BookmarkRequestDto {
+    private Long userId;
+    private Long newsId;
+}

--- a/Backend/src/main/java/com/fourstit/pocari/dto/NewsDto.java
+++ b/Backend/src/main/java/com/fourstit/pocari/dto/NewsDto.java
@@ -30,6 +30,8 @@ public class NewsDto {
 
     private String title;
 
+    private long categoryId;
+
     public static NewsDto fromEntity(News news) {
         NewsDto newsDto = new NewsDto();
         newsDto.setId(news.getNewsId());
@@ -40,6 +42,7 @@ public class NewsDto {
         newsDto.setNewsPaper(news.getNewspaper());
         newsDto.setSummary(news.getSummary());
         newsDto.setTitle(news.getTitle());
+        newsDto.setCategoryId(news.getCategoryId());
         return newsDto;
     }
 
@@ -53,6 +56,7 @@ public class NewsDto {
         news.setNewspaper(this.getNewsPaper());
         news.setSummary(this.getSummary());
         news.setTitle(this.getTitle());
+        news.setCategoryId(news.getCategoryId());
         return news;
     }
 

--- a/Frontend/src/components/newsdetails/Newsdetails.vue
+++ b/Frontend/src/components/newsdetails/Newsdetails.vue
@@ -75,7 +75,7 @@ export default {
       }
 
       try {
-        await axios.post('http://localhost:8080/api/bookmark', {
+        await axios.post('http://localhost:8080/api/createbookmark', {
           userId: userStore.user.id,
           newsId: route.params.newsNo
         });

--- a/Frontend/src/components/newsdetails/Newsdetails.vue
+++ b/Frontend/src/components/newsdetails/Newsdetails.vue
@@ -12,7 +12,7 @@
         </div>
         <div class="right">
           <span class="views">조회수</span>
-          <button class="bookmark">북마크에 추가</button>
+          <button @click="createBookmark" class="bookmark">북마크에 추가</button>
         </div>
       </div>
 
@@ -56,9 +56,40 @@
 
 import axios from 'axios';
 import '@/components/newsdetails/Newsdetails.css'
+import { useRouter, useRoute } from 'vue-router';
+import { useUserStore } from '@/store/user';
 
 export default {
   name: "DetailNews",
+  setup(){
+    const userStore = useUserStore();
+    const router = useRouter();
+    const route = useRoute();
+
+    const createBookmark = async () => {
+      if (!userStore.isLogIn) {
+        alert('로그인이 필요합니다.');
+        router.push('/login');
+        
+        return;
+      }
+
+      try {
+        await axios.post('http://localhost:8080/api/bookmark', {
+          userId: userStore.user.id,
+          newsId: route.params.newsNo
+        });
+        
+        alert("북마크 추가 완료");
+      } catch (error) {
+        console.error('북마크 추가 실패:', error);
+      }
+    };
+    return {
+      createBookmark,
+    };
+  },
+
   data() {
     return {
       news: {}// api로부터 받은 데이터 저장

--- a/Frontend/src/store/bookmark.js
+++ b/Frontend/src/store/bookmark.js
@@ -1,0 +1,12 @@
+import { defineStore } from 'pinia';
+
+export const useBookmarkStore = defineStore('bookmark', {
+    state: () => ({
+        bookmarkList: [], // 북마크 리스트를 저장
+    }),
+    actions: {
+        setBookmarkList(bookmarks) {
+            this.bookmarkList = bookmarks;
+        },
+    },
+});

--- a/Frontend/src/store/user.js
+++ b/Frontend/src/store/user.js
@@ -1,0 +1,19 @@
+import { defineStore } from 'pinia';
+
+
+export const useUserStore = defineStore('user', {
+    state: () => ({
+        user: null,
+    }),
+    getters: {
+        isLogIn: (state) => !!state.user
+    },
+    actions: {
+        setUser(user){
+            this.user = user;
+        },
+        logout(){
+            this.user = null;
+        }
+    },
+});


### PR DESCRIPTION
<details>
  <summary>로그인 상태에서 북마크 추가</summary>
  - userid 1번으로 임시 설정

```js
import { useUserStore } from '@/store/user'; // 테스트용 임포트
// 테스트용
const userStore = useUserStore();
userStore.setUser({ id: 1 });
```

![image](https://github.com/user-attachments/assets/6100688e-4591-45af-8851-cffbb763f31c)
- DB에 데이터 정상 추가 확인
![image](https://github.com/user-attachments/assets/5076c636-1bd9-4caf-999b-c08fa6e07c1c)
</details>



### 프론트 작업 내용
- pinia 
   - 사용자 로그인 상태 관리
   - 추후 사용할 북마크 리스트 상태 관리 js 추가
- 북마크 추가 관련 기능
   - 로그인 상태에서 `북마크 추가` => 사용자 북마크 리스트에 추가
   - 로그아웃 상태에서 `북마크 추가` => 안내창 띄운 후, 로그인 페이지로 이동

### 백엔드 작업 내용
- 북마크 추가를 위한 post API
   - reqDto 추가
- newsDto에 카테고리 추가
---
#### 다음에 할일
- [ ] 하단 < >에 v-if 조건 추가(북마크 리스트 통해서 기사에 접속하면 < > 활성화)
- [ ] 하단 목록 보기에도 로그인 상태 구분해서 북마크 목록으로 이동하게끔 구현
- [ ] 테이블에 조회수 추가
- [ ] css 일부 수정 예정