### PR TITLE
[feat] 목록으로 돌아가기 버튼 라우팅

### DIFF
--- a/Frontend/src/components/newsdetails/Newsdetails.vue
+++ b/Frontend/src/components/newsdetails/Newsdetails.vue
@@ -44,7 +44,7 @@
       </div>
       
       <div class="back-to-list">
-        <router-link to="/main" class="back-button">목록으로 돌아가기</router-link>
+        <router-link :to="backToList" class="back-button">목록으로 돌아가기</router-link>
       </div>
 
     </div>
@@ -58,6 +58,7 @@ import axios from 'axios';
 import '@/components/newsdetails/Newsdetails.css'
 import { useRouter, useRoute } from 'vue-router';
 import { useUserStore } from '@/store/user';
+import { computed } from 'vue';
 
 export default {
   name: "DetailNews",
@@ -85,8 +86,14 @@ export default {
         console.error('북마크 추가 실패:', error);
       }
     };
+
+    const backToList = computed(() => {
+      return userStore.isLogIn ? '/bookmark' : '/';
+    });
+
     return {
       createBookmark,
+      backToList
     };
   },
 
@@ -95,9 +102,11 @@ export default {
       news: {}// api로부터 받은 데이터 저장
     };
   },
+  
   created() {
     this.fetchNewsDetail();
   },
+
   methods: {
     async fetchNewsDetail() {
       try {
@@ -109,6 +118,7 @@ export default {
       }
     }
   },
+  
   computed: {
     splitContent() {
       // 문장마다 나누기


### PR DESCRIPTION
<details>
  <summary><b>로그아웃 상태, 메인으로</b></summary>

![비로그인, 목록으로 돌아가기](https://github.com/user-attachments/assets/e905fb3e-2802-4c73-9757-1be7634ed871)
</details>

<details>
  <summary><b>로그인 상태, 북마크로</b></summary>

![사용자 로그인, 목록으로 돌아가기](https://github.com/user-attachments/assets/420440f6-38f4-4272-aac4-041c0871ec3b)
</details>



### 프론트 작업 내용
- 로그인 상태에서 `목록으로 이동` => 사용자 북마크 리스트로 이동
- 로그아웃 상태에서 `목록으로 이동` => 메인페이지로 이동

---
#### 다음에 할일
- [ ] 하단 < >에 v-if 조건 추가(북마크 리스트 통해서 기사에 접속하면 < > 활성화)
- [ ] 테이블에 조회수 추가
- [ ] css 일부 수정 예정


