### PR TITLE
[frontend] feat: add bookmark navigator routing

### DIFF
--- a/Frontend/src/components/common/HeaderIT.vue
+++ b/Frontend/src/components/common/HeaderIT.vue
@@ -44,6 +44,7 @@
                     </li>
                 </ul>
             </div>
+            <RouterLink class="nav-link" :to="{ name: 'bookmark' }" style="font-size: 15px;">북마크로 이동</RouterLink>
         </div>
     </nav>
 </template>

--- a/Frontend/src/components/newsdetails/Newsdetails.js
+++ b/Frontend/src/components/newsdetails/Newsdetails.js
@@ -5,10 +5,12 @@ import { useRouter, useRoute } from 'vue-router';
 import { computed, onMounted } from 'vue';
 import { useUserStore } from '@/store/user';
 import { useBookmarkStore } from '@/store/bookmark';
+import { useNavigatorStore } from '@/store/navigator';
 
 export default function useNewsdetails() {
     const userStore = useUserStore();
     const bookmarkStore = useBookmarkStore();
+    const naviStore = useNavigatorStore();
 
     const router = useRouter();
     const route = useRoute();
@@ -17,6 +19,11 @@ export default function useNewsdetails() {
 
     const bookmarkList = computed(() => bookmarkStore.bookmarkList);
     const isBookmarked = computed(() => bookmarkList.value.some(news => news.newsId === curNewsNo));
+    
+    router.beforeEach((to, from) => {
+        // console.log("to", to.name, "from, ", from.name);
+            naviStore.setPrev(from.name);
+    });
 
     const fetchBookmarkList = async () => {
         if (userStore.isLogIn) {
@@ -36,7 +43,7 @@ export default function useNewsdetails() {
         
         return;
         };
-        // console.log("isBookmarked: ", isBookmarked.value);
+
         try {
         if(isBookmarked.value){
         
@@ -74,7 +81,13 @@ export default function useNewsdetails() {
     });
 
     const backToList = computed(() => {
-        return userStore.isLogIn ? '/bookmark' : '/';
+        // console.log("naviStore.prev, ", naviStore.prev);
+        if(naviStore.prev === 'bookmark'){// 이전 페이지가 북마크면
+            return '/bookmark';
+        }
+        else{
+            return '/';
+        }
     });
 
     return {

--- a/Frontend/src/store/navigator.js
+++ b/Frontend/src/store/navigator.js
@@ -1,0 +1,13 @@
+import { defineStore } from 'pinia';
+
+export const useNavigatorStore = defineStore('navigator', {
+    state: () => ({
+        prev: null,
+    }),
+    actions: {
+        setPrev(route){
+            this.prev = route;
+            console.log("setPrev", route);
+        },
+    },
+});


### PR DESCRIPTION
### 프론트엔드 작업 내용
- 하단 `목록으로 돌아가기`
   - 이전 페이지가 `북마크` 페이지면 북마크 목록으로 이동
   - 그 외 경우에는 메인 페이지로 이동
- pinia 이전 페이지 상태 관리하는 navigator.js 추가
- [**임시**] 북마크 페이지로 이동하기 위한 임시 라우트링크 추가