### PR TITLE
[front + back] feat: 헤더 글씨 색상 수정 및 메인 페이지 조회수 상위 3건 조회

### DIFF
--- a/Backend/src/main/java/com/fourstit/pocari/controller/MainController.java
+++ b/Backend/src/main/java/com/fourstit/pocari/controller/MainController.java
@@ -201,6 +201,11 @@ public class MainController {
         return ResponseEntity.ok("User information updated successfully");
     }
 
+    @GetMapping("/main/top")
+    public List<News> getTop3News() {
+        return newsRepository.findTop3ByOrderByViewsDesc();
+    }
+
     //Todo: 뉴스 작성, 여유있으면 프론트 구현 @uzz99
 //    @PostMapping("/createnews")
 //    public void createNews(@RequestBody NewsDto newsDTO) {

--- a/Backend/src/main/java/com/fourstit/pocari/repository/NewsRepository.java
+++ b/Backend/src/main/java/com/fourstit/pocari/repository/NewsRepository.java
@@ -11,4 +11,6 @@ import java.util.List;
 public interface NewsRepository extends JpaRepository<News, Long> {
     @Query("SELECT n FROM News n WHERE n.categoryId IN :categoryIds")
     List<News> findByCategoryIdIn(@Param("categoryIds") List<Integer> categoryIds);
+
+    List<News> findTop3ByOrderByViewsDesc();
 }

--- a/Frontend/src/components/MainIT.vue
+++ b/Frontend/src/components/MainIT.vue
@@ -1,54 +1,47 @@
 <template>
+    <section class="main-section">
     <div class="container px-lg-5" style="margin-top: 80px;">
         <div class="p-4 p-lg-5 bg-light rounded-3 text-center">
-            <swiper :autoplay="{
-                delay: 3000,
-                disableOnInteraction: false,
-            }" :navigation="true" :loop="true" :pagination="{
-        clickable: true,
-    }" :modules="modules" class="mySwiper">
-                <swiper-slide>
+            <swiper
+                :autoplay="{
+                    delay: 3000,
+                    disableOnInteraction: false
+                }"
+                :navigation="true"
+                :loop="true"
+                :pagination="{
+                    clickable: true
+                }"
+                :modules="modules"
+                class="swiper"
+            >
+                <swiper-slide v-for="(news, index) in newsTop3" :key="index">
+                    <router-link :to="`/detail/${news.newsId}`" class="news-item-link">
                     <div class="slide-content">
-                        <img src="../image/image1.jpg" alt="Image 1" class="slide-image">
+                        <img :src="news.image" class="main-news-image" />
                         <div class="slide-text">
-                            <h2>Title 1</h2>
-                            <p id="swp">This is the description for the first slide. It can be as long or short as you need.</p>
+                            <h2>{{ news.title }}</h2>
+                            <p id="swp">{{ news.content }}</p>
                         </div>
                     </div>
-                </swiper-slide>
-                <swiper-slide>
-                    <div class="slide-content">
-                        <img src="../image/image2.jpg" alt="Image 2" class="slide-image">
-                        <div class="slide-text">
-                            <h2>Title 1</h2>
-                            <p>This is the description for the first slide. It can be as long or short as you need.</p>
-                        </div>
-                    </div>
-                </swiper-slide>
-                <swiper-slide>
-                    <div class="slide-content">
-                        <img src="../image/image3.jpg" alt="Image 3" class="slide-image">
-                        <div class="slide-text">
-                            <h2>Title 1</h2>
-                            <p>This is the description for the first slide. It can be as long or short as you need.</p>
-                        </div>
-                    </div>
+                    </router-link>
                 </swiper-slide>
             </swiper>
         </div>
     </div>
-    <CardIT/>
+</section>
+    <CardIT />
 </template>
 
 <script>
 import { Swiper, SwiperSlide } from 'swiper/vue';
-import CardIT from './CardIT.vue';
-
+import { ref, onMounted } from 'vue';
 import 'swiper/css';
 import 'swiper/css/navigation';
 import 'swiper/css/pagination';
-
 import { Autoplay, Navigation, Pagination } from 'swiper/modules';
+import NewsService from '@/services/NewsService';
+import CardIT from './CardIT.vue';
 
 export default {
     components: {
@@ -57,19 +50,52 @@ export default {
         CardIT
     },
     setup() {
-        return {
-            modules: [Navigation, Pagination, Autoplay],
+        const newsTop3 = ref([]);
+        const autoplayOptions = {
+            delay: 3000,
+            disableOnInteraction: false
         };
-    },
-};
+        const modules = [Autoplay, Navigation, Pagination];
 
+        const getTop3News = async () => {
+            try {
+                const response = await NewsService.getTop3News();
+                newsTop3.value = response.data;
+                console.log(newsTop3.value);
+            } catch (error) {
+                console.error('Error fetching news:', error);
+            }
+        };
+
+        onMounted(() => {
+            getTop3News();
+        });
+
+        return {
+            modules,
+            autoplayOptions,
+            newsTop3
+        };
+    }
+};
 </script>
 
 <style scoped>
+.main-section {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.container {
+    width: 1286px;
+}
+
 .swiper {
     width: 100%;
-    height: 100%;
+    height: auto;
 }
+
 /* . . . 아래로 띄움 */
 #swp { 
     margin-bottom: 50px;
@@ -79,17 +105,40 @@ export default {
     text-align: center;
     font-size: 18px;
     background: #fff;
-
     display: flex;
     justify-content: center;
     align-items: center;
+    position: relative;
 }
 
-.swiper-slide img {
+.slide-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    width: 100%;
+    padding: 10px;
+    box-sizing: border-box;
+    margin-bottom: 50px;
+}
+
+.main-news-image {
     display: block;
-    width: 1050px;
-    height: 500px;
-    object-fit: cover;
+    width: auto;
+    width: 800px;
+    height: 300px;
 }
 
+.slide-text {
+    text-align: center;
+    margin-top: 10px;
+    width: 100%; 
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    overflow: hidden; 
+    text-overflow: ellipsis;
+}
 </style>
+

--- a/Frontend/src/components/common/HeaderIT.vue
+++ b/Frontend/src/components/common/HeaderIT.vue
@@ -1,7 +1,7 @@
 <template>
     <nav class="navbar navbar-expand-lg bg-navbar fixed-top">
         <div class="container px-lg-5">
-            <RouterLink class="navbar-brand" :to="{ name: 'main' }" style="font-size: 20px;">4ST-IT</RouterLink>
+            <RouterLink class="navbar-brand" :to="{ name: 'main' }" style="font-size: 20px; color: white;">4ST-IT</RouterLink>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
                 data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false"
                 aria-label="Toggle navigation">
@@ -16,7 +16,7 @@
                 </div>
                 <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
                     <li v-if="!isLoggedIn" class="nav-item">
-                        <RouterLink class="nav-link" :to="{ name: 'JoinView' }" style="font-size: 15px;">회원가입</RouterLink>
+                        <RouterLink class="nav-link" :to="{ name: 'JoinView' }" style="font-size: 15px; color: white;">회원가입</RouterLink>
                     </li>
 
                     <!--
@@ -34,13 +34,13 @@
 
                     <li class="nav-item">
 
-                        <RouterLink class="nav-link" :to="{ name: 'login' }" style="font-size: 15px;">로그인</RouterLink>
+                        <RouterLink class="nav-link" :to="{ name: 'login' }" style="font-size: 15px; color: white;">로그인</RouterLink>
                     </li>
                     <li v-if="isLoggedIn" class="nav-item">
-                        <RouterLink class="nav-link" :to="{ name: 'MyPageView' }" style="font-size: 15px;">마이페이지</RouterLink>
+                        <RouterLink class="nav-link" :to="{ name: 'MyPageView' }" style="font-size: 15px; color: white;">마이페이지</RouterLink>
                     </li>
                     <li v-if="isLoggedIn" class="nav-item">
-                        <a class="nav-link" href="#!" style="font-size: 15px;" @click="logout">로그아웃</a>
+                        <a class="nav-link" href="#!" style="font-size: 15px; color: white;" @click="logout">로그아웃</a>
                     </li>
                 </ul>
             </div>

--- a/Frontend/src/services/NewsService.js
+++ b/Frontend/src/services/NewsService.js
@@ -15,6 +15,10 @@ class NewsService {
       params: { query },
     });
   }
+  // 상위 3개 뉴스 가져오기
+  getTop3News() {
+    return axios.get(`${NEWS_API_BASE_URL}/top`);
+  }
 }
 
 export default new NewsService();


### PR DESCRIPTION
## 프론트엔드 작업 내용
- 헤더 글씨 흰색으로 수정
- 메인 페이지 슬라이드에 조회수 상위 3건만 보여지도록 수정
- 메인 페이지 슬라이드 -> 상세 페이지 넘어가도록 수정

## 백엔드 작업 내용
- 조회수 상위 3건 조회 API 