### PR TITLE
[fix] bookmark list on logout

### DIFF
--- a/Frontend/src/store/bookmark.js
+++ b/Frontend/src/store/bookmark.js
@@ -13,6 +13,9 @@ export const useBookmarkStore = defineStore('bookmark', {
         },
         deleteBookmark(newsId){
             this.bookmarkList = this.bookmarkList.filter(bookmark => bookmark.newsId !== newsId);
+        },
+        clearBookmarkList() {
+            this.bookmarkList = []; // 북마크 리스트 초기화
         }
     },
 });

--- a/Frontend/src/store/user.js
+++ b/Frontend/src/store/user.js
@@ -1,4 +1,5 @@
 import { defineStore } from 'pinia';
+import { useBookmarkStore } from './bookmark';
 
 export const useUserStore = defineStore('user', {
   state: () => ({
@@ -17,8 +18,12 @@ export const useUserStore = defineStore('user', {
       this.user = null;
       this.isLoggedIn = false;
 
+
       localStorage.removeItem('user');
       localStorage.removeItem('isLoggedIn');
+      
+      const bookmarkStore = useBookmarkStore();
+      bookmarkStore.clearBookmarkList();
     },
     loadUserFromStorage() {
       const storedUser = localStorage.getItem('user');


### PR DESCRIPTION
### 고친 내용
- 로그아웃 후 기사에 접속하면 `북마크에 추가`가 아닌 `북마크 삭제`로 뜨는 문제 해결
   - 로그아웃 -> 북마크 리스트 초기화하는 로직 추가